### PR TITLE
Misprint in the InfluxDbOptions name "RetensionPolicy" Fixes #34

### DIFF
--- a/sandbox/MetricsInfluxDBSandboxMvc/appsettings.json
+++ b/sandbox/MetricsInfluxDBSandboxMvc/appsettings.json
@@ -23,7 +23,7 @@
       //"Consistenency": "",
       //"UserName": "",
       //"Password": "",
-      //"RetensionPolicy": ""
+      //"RetentionPolicy": ""
     },
     "HttpPolicy": {
       "BackoffPeriod": "0:0:30",

--- a/src/App.Metrics.Reporting.InfluxDB/InfluxDBOptions.cs
+++ b/src/App.Metrics.Reporting.InfluxDB/InfluxDBOptions.cs
@@ -38,9 +38,9 @@ namespace App.Metrics.Reporting.InfluxDB
 
                 var endpoint = $"write?db={Uri.EscapeDataString(Database)}";
 
-                if (!string.IsNullOrWhiteSpace(RetensionPolicy))
+                if (!string.IsNullOrWhiteSpace(RetentionPolicy))
                 {
-                    endpoint += $"&rp={Uri.EscapeDataString(RetensionPolicy)}";
+                    endpoint += $"&rp={Uri.EscapeDataString(RetentionPolicy)}";
                 }
 
                 if (!string.IsNullOrWhiteSpace(Consistenency))
@@ -82,7 +82,7 @@ namespace App.Metrics.Reporting.InfluxDB
         /// <value>
         ///     The InfluxDB database's retention policy to target.
         /// </value>
-        public string RetensionPolicy { get; set; }
+        public string RetentionPolicy { get; set; }
 
         /// <summary>
         ///     Gets or sets the InfluxDB database username.

--- a/test/App.Metrics.Reporting.InfluxDB.Facts/InfluxDBSettingsTests.cs
+++ b/test/App.Metrics.Reporting.InfluxDB.Facts/InfluxDBSettingsTests.cs
@@ -19,7 +19,7 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
                            {
                                Database = "testdb",
                                BaseUri = new Uri("http://localhost"),
-                               RetensionPolicy = "defaultrp",
+                               RetentionPolicy = "defaultrp",
                                Consistenency = "consistency"
                            };
 


### PR DESCRIPTION
### Details on the issue fix or feature implementation

- Renamed the "RetensionPolicy" property of InfluxDbOptions. Fixes #34

### Confirm the following

- [x] I have ensured that I have merged the latest changes from the dev branch
- [x] I have successfully run a [local build](https://github.com/alhardy/AppMetrics#how-to-build)
- [x] I have included unit tests for the issue/feature
- [x] I have included the github issue number in my commits 