### PR TITLE
#38 Create default retention policy for database in case of creation a new database

### DIFF
--- a/src/App.Metrics.Reporting.InfluxDB/Client/DefaultLineProtocolClient.cs
+++ b/src/App.Metrics.Reporting.InfluxDB/Client/DefaultLineProtocolClient.cs
@@ -93,7 +93,15 @@ namespace App.Metrics.Reporting.InfluxDB.Client
 
                 var content = new StringContent(string.Empty, Encoding.UTF8);
 
-                var response = await _httpClient.PostAsync($"query?q=CREATE DATABASE \"{Uri.EscapeDataString(_influxDbOptions.Database)}\"", content, cancellationToken);
+                string query = $"query?q=CREATE DATABASE \"{Uri.EscapeDataString(_influxDbOptions.Database)}\"";
+
+                if (_influxDbOptions.CreateDatabaseRetentionPolicy != null &&
+                    _influxDbOptions.CreateDatabaseRetentionPolicy.TryApply(out string withClause))
+                {
+                    query = query + " " + withClause;
+                }
+
+                var response = await _httpClient.PostAsync(query, content, cancellationToken);
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/App.Metrics.Reporting.InfluxDB/InfluxDBOptions.cs
+++ b/src/App.Metrics.Reporting.InfluxDB/InfluxDBOptions.cs
@@ -99,5 +99,13 @@ namespace App.Metrics.Reporting.InfluxDB
         ///  The flag indicating whether or not to create the specifried database if it does not exist
         /// </value>
         public bool CreateDataBaseIfNotExists { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the InfluxDB retention policy options used during an attempt to create the specified database if it does not exist.
+        /// </summary>
+        /// <value>
+        ///     The InfluxDB retention policy options <see cref="RetentionPolicyOptions"/>.
+        /// </value>
+        public RetentionPolicyOptions CreateDatabaseRetentionPolicy { get; set; }
     }
 }

--- a/src/App.Metrics.Reporting.InfluxDB/RetentionPolicyOptions.cs
+++ b/src/App.Metrics.Reporting.InfluxDB/RetentionPolicyOptions.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="RetentionPolicyOptions.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text;
+
+namespace App.Metrics.Reporting.InfluxDB
+{
+    /// <summary>
+    /// Single retention policy associated with the created database. If you do not specify one of the properties, the relevant behavior defaults to the autogen retention policy settings.
+    /// </summary>
+    public class RetentionPolicyOptions
+    {
+        /// <summary>
+        /// Gets or sets the Duration determines how long InfluxDB keeps the data.
+        /// </summary>
+        /// <value>
+        /// The retention policy duration. The minimum duration for a retention policy is one hour.
+        /// </value>
+        public TimeSpan? Duration { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Name determines policy name.
+        /// </summary>
+        /// <value>
+        /// The retention policy name.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Replication determines how many independent copies of each point are stored in the cluster. Replication factors do not serve a purpose with single node instances.
+        /// </summary>
+        /// <value>
+        /// The retention policy replication. Number of data nodes.
+        /// </value>
+        public int? Replication { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ShardDuration determines the time range covered by a shard group.
+        /// </summary>
+        /// <value>
+        /// The retention policy shard duration. The minimum allowable SHARD GROUP DURATION is 1h
+        /// </value>
+        public TimeSpan? ShardDuration { get; set; }
+
+        public bool TryApply(out string clause)
+        {
+            clause = null;
+            bool hasName = !string.IsNullOrWhiteSpace(Name);
+            bool hasNonDefaultValues = Duration.HasValue || Replication.HasValue || ShardDuration.HasValue || hasName;
+            StringBuilder stringBuilder = new StringBuilder("WITH", 100);
+
+            if (hasNonDefaultValues)
+            {
+                if (Duration.HasValue)
+                {
+                    stringBuilder.Append(" DURATION ");
+                    stringBuilder.Append((int)Math.Floor(Duration.Value.TotalMinutes));
+                    stringBuilder.Append("m");
+                }
+
+                if (Replication.HasValue)
+                {
+                    stringBuilder.Append(" REPLICATION ");
+                    stringBuilder.Append(Replication.Value);
+                }
+
+                if (ShardDuration.HasValue)
+                {
+                    stringBuilder.Append(" SHARD DURATION ");
+                    stringBuilder.Append((int)Math.Floor(ShardDuration.Value.TotalMinutes));
+                    stringBuilder.Append("m");
+                }
+
+                if (hasName)
+                {
+                    stringBuilder.Append(" NAME \"");
+                    stringBuilder.Append(Uri.EscapeDataString(Name));
+                    stringBuilder.Append("\"");
+                }
+
+                clause = stringBuilder.ToString();
+            }
+
+            return hasNonDefaultValues;
+        }
+    }
+}

--- a/test/App.Metrics.Reporting.InfluxDB.Facts/DefaultLineProtocolClientTests.cs
+++ b/test/App.Metrics.Reporting.InfluxDB.Facts/DefaultLineProtocolClientTests.cs
@@ -206,5 +206,68 @@ namespace App.Metrics.Reporting.InfluxDB.Facts
 
             response.Success.Should().BeTrue();
         }
+
+        [Fact]
+        public async Task Can_create_database_without_retention_policy()
+        {
+            // Arrange
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+            httpMessageHandlerMock.Protected().Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
+
+            var settings = new InfluxDbOptions
+                           {
+                               BaseUri = new Uri("http://localhost"),
+                               Database = "influx",
+                               CreateDataBaseIfNotExists = true
+                           };
+
+            var policy = new HttpPolicy();
+            var influxClient = MetricsInfluxDbReporterBuilder.CreateClient(settings, policy, httpMessageHandlerMock.Object);
+
+            // Act
+            await influxClient.WriteAsync(Payload, CancellationToken.None);
+
+            httpMessageHandlerMock.Protected().Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(message => message.RequestUri.ToString().EndsWith("CREATE DATABASE \"influx\"")),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task Can_create_database_with_retention_policy()
+        {
+            // Arrange
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+
+            httpMessageHandlerMock.Protected().Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)));
+
+            var settings = new InfluxDbOptions
+                           {
+                               BaseUri = new Uri("http://localhost"),
+                               Database = "influx",
+                               CreateDataBaseIfNotExists = true,
+                               CreateDatabaseRetentionPolicy = new RetentionPolicyOptions { Duration = TimeSpan.FromMinutes(70) }
+                           };
+
+            var policy = new HttpPolicy();
+            var influxClient = MetricsInfluxDbReporterBuilder.CreateClient(settings, policy, httpMessageHandlerMock.Object);
+
+            // Act
+            await influxClient.WriteAsync(Payload, CancellationToken.None);
+
+            httpMessageHandlerMock.Protected().Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(message => message.RequestUri.ToString().EndsWith("CREATE DATABASE \"influx\" WITH DURATION 70m")),
+                ItExpr.IsAny<CancellationToken>());
+        }
     }
 }

--- a/test/App.Metrics.Reporting.InfluxDB.Facts/RetentionPolicyOptionsTests.cs
+++ b/test/App.Metrics.Reporting.InfluxDB.Facts/RetentionPolicyOptionsTests.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="RetentionPolicyOptionsTests.cs" company="App Metrics Contributors">
+// Copyright (c) App Metrics Contributors. All rights reserved.
+// </copyright>
+
+using System;
+using Xunit;
+
+namespace App.Metrics.Reporting.InfluxDB.Facts
+{
+    public class RetentionPolicyOptionsTests
+    {
+        [Fact]
+        public void TryApplyDefaultRetentionPolicy()
+        {
+            RetentionPolicyOptions options = new RetentionPolicyOptions();
+
+            bool result = options.TryApply(out var clause);
+
+            Assert.False(result);
+            Assert.Null(clause);
+        }
+
+        [Theory]
+        [InlineData(null,null,null,null,false,null)]
+        [InlineData(65, null, null, null, true, "WITH DURATION 65m")]
+        [InlineData(null, 3, null, null, true, "WITH REPLICATION 3")]
+        [InlineData(null, null, 60, null, true, "WITH SHARD DURATION 60m")]
+        [InlineData(null, null, null, "any Name", true, "WITH NAME \"any%20Name\"")]
+        [InlineData(65, 3, 60, "any Name", true, "WITH DURATION 65m REPLICATION 3 SHARD DURATION 60m NAME \"any%20Name\"")]
+
+        public void TryApplyRetentionPolicy(
+            int? duration,
+            int? replication,
+            int? shardDuration,
+            string name,
+            bool expected,
+            string expectedClause)
+        {
+            RetentionPolicyOptions options =
+                new RetentionPolicyOptions
+                {
+                    Name = name,
+                    Duration = duration.HasValue ? TimeSpan.FromMinutes(duration.Value) : (TimeSpan?)null ,
+                    Replication = replication,
+                    ShardDuration = shardDuration.HasValue ? TimeSpan.FromMinutes(shardDuration.Value) : (TimeSpan?)null
+                };
+
+            bool result = options.TryApply(out var clause);
+
+            Assert.Equal(expected, result);
+            Assert.Equal(expectedClause, clause);
+        }
+    }
+}


### PR DESCRIPTION
### The issue or feature being addressed

#38 

### Details on the issue fix or feature implementation

- added property to `InfluxDbOptions` to control creation of retention policy


### Confirm the following

- [X] I have ensured that I have merged the latest changes from the dev branch
- [X] Local build in VS was successful, local build with script failed with message "Unable to load the service index for source https://api.nuget.org/v3/index.json" 
- [X] I have included unit tests for the issue/feature
- [X] I have included the github issue number in my commits 